### PR TITLE
RAC-6232: upgrade traceur from 0.0.33 to 0.0.111

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "url": "https://github.com/angular/di.js/issues"
   },
   "dependencies": {
-    "traceur": "0.0.33",
+    "traceur": "0.0.111",
     "es6-shim": "~0.11.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix **case**: Job.Catalog.GenerateSku assigns a matching sku:
**Error**:  TypeError: ctx.stylize is not a function
**Cause**: 
The module "util.js" in node 6 called "Object.assign()" in method "inspect()"(https://github.com/nodejs/node/blob/v6.x-staging/lib/util.js#L182).  
```
ctx = Object.assign({}, inspect.defaultOptions, ctx, opts);
```
"utils" in node 4 doesn't do that.
 The "Object.assign" is overwritten by module "traceur" (node_modules/traceur/bin/traceur-runtime.js line 2320) which accepts only 1 source. 
   That caused the object ctx doesn't contain the method "stylize()"

**Fix**:
Upgrade traceur from 0.0.33 to 0.0.111

@anhou @mcgg 
